### PR TITLE
feat: try to fix anonymous clipboard with deprated method; feat: adde…

### DIFF
--- a/web/src/views/MobileHome.vue
+++ b/web/src/views/MobileHome.vue
@@ -798,14 +798,14 @@ onMounted(async () => {
                         </template>
                       </n-tag>
                       <n-tag
-                        @click="copyText(playerInfo.player_uid)"
+                        @click="copyText(playerInfo.steam_id)"
                         class="mt-1"
                         type="info"
                         size="small"
                         icon-placement="right"
                         ghost
                       >
-                        UID: {{ playerInfo.player_uid }}
+                        Steam64: {{ playerInfo.steam_id }}
                         <template #icon>
                           <n-icon><ContentCopyFilled /></n-icon>
                         </template>

--- a/web/src/views/MobileHome.vue
+++ b/web/src/views/MobileHome.vue
@@ -284,10 +284,9 @@ const copyText = (text) => {
 
   try {
     const successful = document.execCommand('copy');
-    const msg = successful ? 'successful' : 'unsuccessful';
-    console.log('Copy text command was ' + msg);
+    message.success(t("message.copysuccess"));
   } catch (err) {
-    console.error('Unable to copy', err);
+    message.error(t("message.copyerr", { err: err }));
   }
 
   document.body.removeChild(textarea);

--- a/web/src/views/MobileHome.vue
+++ b/web/src/views/MobileHome.vue
@@ -276,18 +276,21 @@ const createPlayerPalsColumns = () => {
   ];
 };
 
-const copyText = async (text) => {
-  if (!navigator.clipboard) {
-    message.error(t("message.copyfail"));
-    return;
-  }
+const copyText = (text) => {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  document.body.appendChild(textarea);
+  textarea.select();
 
   try {
-    await navigator.clipboard.writeText(text);
-    message.success(t("message.copysuccess"));
+    const successful = document.execCommand('copy');
+    const msg = successful ? 'successful' : 'unsuccessful';
+    console.log('Copy text command was ' + msg);
   } catch (err) {
-    message.error(t("message.copyerr", { err: err }));
+    console.error('Unable to copy', err);
   }
+
+  document.body.removeChild(textarea);
 };
 
 // login
@@ -781,6 +784,19 @@ onMounted(async () => {
                           }}
                         </n-tag>
                       </div>
+                      <n-tag
+                        @click="copyText(playerInfo.player_uid)"
+                        class="mt-1"
+                        type="info"
+                        size="small"
+                        icon-placement="right"
+                        ghost
+                      >
+                        UID: {{ playerInfo.player_uid }}
+                        <template #icon>
+                          <n-icon><ContentCopyFilled /></n-icon>
+                        </template>
+                      </n-tag>
                       <n-tag
                         @click="copyText(playerInfo.player_uid)"
                         class="mt-1"

--- a/web/src/views/PcHome.vue
+++ b/web/src/views/PcHome.vue
@@ -286,18 +286,21 @@ const createPlayerPalsColumns = () => {
   ];
 };
 
-const copyText = async (text) => {
-  if (!navigator.clipboard) {
-    message.error(t("message.copyfail"));
-    return;
-  }
+const copyText = (text) => {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  document.body.appendChild(textarea);
+  textarea.select();
 
   try {
-    await navigator.clipboard.writeText(text);
-    message.success(t("message.copysuccess"));
+    const successful = document.execCommand('copy');
+    const msg = successful ? 'successful' : 'unsuccessful';
+    console.log('Copy text command was ' + msg);
   } catch (err) {
-    message.error(t("message.copyerr", { err: err }));
+    console.error('Unable to copy', err);
   }
+
+  document.body.removeChild(textarea);
 };
 
 // login
@@ -730,6 +733,19 @@ onMounted(async () => {
                       ghost
                     >
                       UID: {{ playerInfo.player_uid }}
+                      <template #icon>
+                        <n-icon><ContentCopyFilled /></n-icon>
+                      </template>
+                    </n-button>
+                    <n-button
+                      @click="copyText(playerInfo.steam_id)"
+                      class="ml-3"
+                      type="info"
+                      size="small"
+                      icon-placement="right"
+                      ghost
+                    >
+                      Steam64: {{ playerInfo.steam_id }}
                       <template #icon>
                         <n-icon><ContentCopyFilled /></n-icon>
                       </template>

--- a/web/src/views/PcHome.vue
+++ b/web/src/views/PcHome.vue
@@ -294,10 +294,9 @@ const copyText = (text) => {
 
   try {
     const successful = document.execCommand('copy');
-    const msg = successful ? 'successful' : 'unsuccessful';
-    console.log('Copy text command was ' + msg);
+    message.success(t("message.copysuccess"));
   } catch (err) {
-    console.error('Unable to copy', err);
+    message.error(t("message.copyerr", { err: err }));
   }
 
   document.body.removeChild(textarea);


### PR DESCRIPTION
…d Steam64ID button with copy button.

由于安全域问题（大部分用这个的独立应该都绑定了域名但是没有 TLS）
尝试用以前的老方法来实现文本复制

另外，查看了一下 bolt 数据库里面有存储玩家的 steam_id，新增了一个控件展示。

由于 go 的 dist 文件原因，没有测试是否生效。