### PR TITLE
Steam_id show and try to fix copy issue in safe domain.

### DIFF
--- a/web/src/views/MobileHome.vue
+++ b/web/src/views/MobileHome.vue
@@ -219,18 +219,20 @@ const percentageHP = (hp, max_hp) => {
   return ((hp / max_hp) * 100).toFixed(2);
 };
 
-const copyText = async (text) => {
-  if (!navigator.clipboard) {
-    message.error(t("message.copyfail"));
-    return;
-  }
+const copyText = (text) => {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  document.body.appendChild(textarea);
+  textarea.select();
 
   try {
-    await navigator.clipboard.writeText(text);
+    const successful = document.execCommand('copy');
     message.success(t("message.copysuccess"));
   } catch (err) {
     message.error(t("message.copyerr", { err: err }));
   }
+
+  document.body.removeChild(textarea);
 };
 
 // login
@@ -758,6 +760,19 @@ onMounted(async () => {
                         ghost
                       >
                         UID: {{ playerInfo.player_uid }}
+                        <template #icon>
+                          <n-icon><ContentCopyFilled /></n-icon>
+                        </template>
+                      </n-tag>
+                      <n-tag
+                        @click="copyText(playerInfo.steam_id)"
+                        class="mt-1"
+                        type="info"
+                        size="small"
+                        icon-placement="right"
+                        ghost
+                      >
+                        Steam64: {{ playerInfo.steam_id }}
                         <template #icon>
                           <n-icon><ContentCopyFilled /></n-icon>
                         </template>

--- a/web/src/views/PcHome.vue
+++ b/web/src/views/PcHome.vue
@@ -327,18 +327,20 @@ const createPlayerPalsColumns = () => {
   ];
 };
 
-const copyText = async (text) => {
-  if (!navigator.clipboard) {
-    message.error(t("message.copyfail"));
-    return;
-  }
+const copyText = (text) => {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  document.body.appendChild(textarea);
+  textarea.select();
 
   try {
-    await navigator.clipboard.writeText(text);
+    const successful = document.execCommand('copy');
     message.success(t("message.copysuccess"));
   } catch (err) {
     message.error(t("message.copyerr", { err: err }));
   }
+
+  document.body.removeChild(textarea);
 };
 
 // login
@@ -786,6 +788,19 @@ onMounted(async () => {
                       ghost
                     >
                       UID: {{ playerInfo.player_uid }}
+                      <template #icon>
+                        <n-icon><ContentCopyFilled /></n-icon>
+                      </template>
+                    </n-button>
+                    <n-button
+                      @click="copyText(playerInfo.steam_id)"
+                      class="ml-3"
+                      type="info"
+                      size="small"
+                      icon-placement="right"
+                      ghost
+                    >
+                      Steam64: {{ playerInfo.steam_id }}
                       <template #icon>
                         <n-icon><ContentCopyFilled /></n-icon>
                       </template>


### PR DESCRIPTION
https://github.com/zaigie/palworld-server-tool/pull/95

由于安全域问题（大部分用这个的独立应该都绑定了域名但是没有 TLS）
尝试用以前的老方法来实现文本复制

另外，查看了一下 bolt 数据库里面有存储玩家的 steam_id，新增了一个控件展示。

由于 go 的 dist 文件原因，没有测试是否生效。