### PR TITLE
Feat/can add the whitelist directly

### DIFF
--- a/service/player.go
+++ b/service/player.go
@@ -305,8 +305,13 @@ func PutWhitelist(db *bbolt.DB, players []database.PlayerW) error {
 			if err != nil {
 				return err
 			}
-			// 生成新玩家的唯一键，这里假设player.PlayerUID是唯一的
-			if err := b.Put([]byte(player.PlayerUID), playerData); err != nil {
+			identifier := player.PlayerUID
+			if identifier == "" {
+				if identifier = player.SteamID; identifier == "" {
+					continue
+				}
+			}
+			if err := b.Put([]byte(identifier), playerData); err != nil {
 				return err
 			}
 		}

--- a/web/src/assets/i18n.js
+++ b/web/src/assets/i18n.js
@@ -17,6 +17,7 @@ const messages = {
       master: "Master",
       player_number: "Player: {number}",
       online_number: "Online: {number}",
+      whitelist: "Whitelist",
     },
     message: {
       warn: "Warning",
@@ -68,6 +69,7 @@ const messages = {
       joinWhitelist: "Join Whitelist",
       search: "Search",
       addNew: "Add New",
+      save: "Save",
     },
     pal: {
       type: "Type",
@@ -103,6 +105,7 @@ const messages = {
       master: "会长",
       player_number: "玩家: {number}",
       online_number: "在线: {number}",
+      whitelist: "白名单",
     },
     message: {
       warn: "警告",
@@ -153,6 +156,7 @@ const messages = {
       joinWhitelist: "加入白名单",
       search: "搜索",
       addNew: "新增",
+      save: "保存",
     },
     pal: {
       type: "类型",

--- a/web/src/assets/i18n.js
+++ b/web/src/assets/i18n.js
@@ -67,11 +67,7 @@ const messages = {
       whitelist: "Whitelist",
       joinWhitelist: "Join Whitelist",
       search: "Search",
-    },
-    input: {
-      nickname: "Nickname",
-      player_uid: "Player Uid",
-      steam_id: "Steam Id",
+      addNew: "Add New",
     },
     pal: {
       type: "Type",
@@ -86,6 +82,9 @@ const messages = {
     },
     input: {
       searchPlaceholder: "Search for pal type and skills",
+      nickname: "Nickname",
+      player_uid: "Player Uid",
+      steam_id: "Steam Id",
     },
   },
   zh: {
@@ -153,11 +152,7 @@ const messages = {
       whitelist: "白名单管理",
       joinWhitelist: "加入白名单",
       search: "搜索",
-    },
-    input: {
-      nickname: "昵称",
-      player_uid: "玩家 Uid",
-      steam_id: "Steam Id",
+      addNew: "新增",
     },
     pal: {
       type: "类型",
@@ -172,6 +167,9 @@ const messages = {
     },
     input: {
       searchPlaceholder: "搜索帕鲁类型、技能",
+      nickname: "昵称",
+      player_uid: "玩家 Uid",
+      steam_id: "Steam Id",
     },
   },
 };

--- a/web/src/views/PcHome.vue
+++ b/web/src/views/PcHome.vue
@@ -489,7 +489,10 @@ const handleAddNewWhiteList = () => {
   })
   virtualListInst.value?.scrollTo({ index: 0 });
 };
-const isWhite=(player)=>{
+const isWhite = (player) => {
+  if(whiteList.value.length === 0) {
+    return false;
+  }
   return whiteList.value.some(whitelistItem => {
     return (
         (whitelistItem.player_uid && whitelistItem.player_uid === player.player_uid) ||

--- a/web/src/views/PcHome.vue
+++ b/web/src/views/PcHome.vue
@@ -428,6 +428,10 @@ const getWhiteList = async () => {
 };
 
 const removeWhiteList = async (player) => {
+  if(player.player_uid || player.steam_id) {
+    message.error(t("message.removewhitefail", { err: "player_uid or steam_id is required" }));
+    return;
+  }
   const { data, statusCode } = await new ApiService().removeWhitelist(player);
   if (statusCode.value === 200) {
     message.success(t("message.removewhitesuccess"));
@@ -475,6 +479,15 @@ const handleAddWhiteList = () => {
     message.error(t("message.requireauth"));
     showAddWhiteListModal.value = true;
   }
+};
+const virtualListInst = ref();
+const handleAddNewWhiteList = () => {
+  whiteList.value.unshift({
+    name: "",
+    player_uid: "",
+    steam_id: "",
+  })
+  virtualListInst.value?.scrollTo({ index: 0 });
 };
 // broadcast
 const showBroadcastModal = ref(false);
@@ -1331,7 +1344,7 @@ onMounted(async () => {
   >
     <div>
       <n-empty description="什么都没有" v-if="whiteList.length==0"> </n-empty>
-      <n-virtual-list v-else style="max-height: 240px" :item-size="42" :items="whiteList">
+      <n-virtual-list ref="virtualListInst" v-else style="max-height: 240px" :item-size="42" :items="whiteList">
         <template #default="{ item }">
           <div :key="item.player_uid" class="flex flex-col item mlr-3 mb-3" style="height: 42px">
             <n-grid >
@@ -1344,7 +1357,7 @@ onMounted(async () => {
               </n-gi>
               <n-gi span="5">
                 <div class="flex justify-end mr-3">
-                  <n-space>
+                  <n-space v-if="item.player_uid || item.steam_id">
                     <n-button
                         strong secondary type="primary"
                         @click="() => {
@@ -1376,6 +1389,13 @@ onMounted(async () => {
     <template #footer>
       <div class="flex justify-end">
         <n-space>
+          <n-button
+              type="primary"
+              @click="handleAddNewWhiteList"
+          >
+            {{ $t("button.addNew") }}
+          </n-button>
+
           <n-button
               type="tertiary"
               @click="

--- a/web/src/views/PcHome.vue
+++ b/web/src/views/PcHome.vue
@@ -489,6 +489,16 @@ const handleAddNewWhiteList = () => {
   })
   virtualListInst.value?.scrollTo({ index: 0 });
 };
+const isWhite=(player)=>{
+  return whiteList.value.some(whitelistItem => {
+    return (
+        (whitelistItem.player_uid && whitelistItem.player_uid === player.player_uid) ||
+        (whitelistItem.steam_id && whitelistItem.steam_id === player.steam_id)
+    );
+  });
+}
+
+
 // broadcast
 const showBroadcastModal = ref(false);
 const broadcastText = ref("");
@@ -620,6 +630,7 @@ onMounted(async () => {
   checkAuthToken();
   getServerInfo();
   await getPlayerList();
+  await getWhiteList();
   loading.value = false;
   setInterval(() => {
     getPlayerList(false);
@@ -810,6 +821,9 @@ onMounted(async () => {
                       <n-tag class="ml-2" type="primary" size="small" round>
                         Lv.{{ player.level }}
                       </n-tag>
+                      <n-tag class="ml-2" type="warning" size="small" round v-if="isWhite(player)">
+                        {{ $t("status.whitelist") }}
+                      </n-tag>
                       <span class="flex-1 pl-2 font-bold line-clamp-1">{{
                         player.nickname
                       }}</span>
@@ -885,6 +899,9 @@ onMounted(async () => {
                           : $t("status.offline")
                       }}</n-tag
                     >
+                    <n-tag class="ml-2" type="warning" round v-if="isWhite(playerInfo)">
+                      {{ $t("status.whitelist") }}
+                    </n-tag>
                     <n-button
                       @click="copyText(playerInfo.player_uid)"
                       class="ml-3"
@@ -1343,7 +1360,7 @@ onMounted(async () => {
     :segmented="segmented"
   >
     <div>
-      <n-empty description="什么都没有" v-if="whiteList.length==0"> </n-empty>
+      <n-empty description="empty" v-if="whiteList.length==0"> </n-empty>
       <n-virtual-list ref="virtualListInst" v-else style="max-height: 240px" :item-size="42" :items="whiteList">
         <template #default="{ item }">
           <div :key="item.player_uid" class="flex flex-col item mlr-3 mb-3" style="height: 42px">
@@ -1412,7 +1429,7 @@ onMounted(async () => {
               @click="putWhiteList"
               strong secondary type="success"
           >
-            保存
+            {{ $t("button.save") }}
           </n-button>
         </n-space>
       </div>

--- a/web/src/views/PcHome.vue
+++ b/web/src/views/PcHome.vue
@@ -419,6 +419,9 @@ const handleWhiteList = () => {
   }
 };
 const getWhiteList = async () => {
+  if (!checkAuthToken()) {
+    return;
+  }
   const { data } = await new ApiService().getWhitelist();
   if (data.value) {
     whiteList.value = data.value;


### PR DESCRIPTION
白名单管理新增了一个新增按钮，可以直接添加没进服玩家的steamId到白名单。目前由于官方的BUG最后一个玩家的steamId获取不到，所以新玩家进服还是可能被踢出。
用户列表新增了一个tag用于标识白名单玩家