### PR TITLE
兼容pal 0.3版本 fix #209 #208 

### DIFF
--- a/module/requirements.txt
+++ b/module/requirements.txt
@@ -1,3 +1,3 @@
 requests
 pyinstaller
-palworld-save-tools==0.22.0
+palworld-save-tools==0.23.0

--- a/module/structurer.py
+++ b/module/structurer.py
@@ -367,7 +367,7 @@ def getPlayerItems(player_uid, dir_path):
     }
     for idx_key in containers_data.keys():
         container_id = str(
-            player_gvas["inventoryInfo"]["value"][idx_key]["value"]["ID"]["value"]
+            player_gvas["InventoryInfo"]["value"][idx_key]["value"]["ID"]["value"]
         )
         if container_id in item_containers:
             # 解析对应的物品容器数据


### PR DESCRIPTION
更新 palworld-save-tools模块 以兼容pal 0.3版本
更新存档用户内容部分的inventoryInfo 0.3版本已经改为大写InventoryInfo
更新 pal-conf 以兼容最新的服务器配置文件

fix #209 
fix #208 

仅仅做了兼容处理 新帕鲁 新技能 翻译未同步 图标资源未更新  