### PR TITLE
对玩家数据接口及相关展示逻辑进行了调整和完善

### DIFF
--- a/api/player.go
+++ b/api/player.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/zaigie/palworld-server-tool/internal/database"
@@ -90,6 +91,17 @@ func listPlayers(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	//未登录隐藏字段
+	if !c.GetBool("loggedIn") {
+		for i := range players {
+			players[i].Ip = ""
+			if players[i].UserId != "" {
+				players[i].UserId = strings.Split(players[i].UserId, "_")[0] + "_"
+			}
+			players[i].SteamId = ""
+		}
+	}
+	//排序
 	if orderBy == "level" {
 		sort.Slice(players, func(i, j int) bool {
 			if desc == "true" {
@@ -132,6 +144,12 @@ func getPlayer(c *gin.Context) {
 		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
+	}
+	//未登录隐藏字段
+	if !c.GetBool("loggedIn") {
+		player.Ip = ""
+		player.UserId = ""
+		player.SteamId = ""
 	}
 	c.JSON(http.StatusOK, player)
 }

--- a/api/router.go
+++ b/api/router.go
@@ -67,11 +67,16 @@ func RegisterRouter(r *gin.Engine) {
 		anonymousGroup.GET("/server", getServer)
 		anonymousGroup.GET("/server/tool", getServerTool)
 		anonymousGroup.GET("/server/metrics", getServerMetrics)
-		anonymousGroup.GET("/player", listPlayers)
-		anonymousGroup.GET("/player/:player_uid", getPlayer)
 		anonymousGroup.GET("/online_player", listOnlinePlayers)
 		anonymousGroup.GET("/guild", listGuilds)
 		anonymousGroup.GET("/guild/:admin_player_uid", getGuild)
+	}
+	// 根据登录状态返回不同结果
+	OptionalGroup := apiGroup.Group("")
+	OptionalGroup.Use(auth.OptionalJWTMiddleware())
+	{
+		OptionalGroup.GET("/player", listPlayers)
+		OptionalGroup.GET("/player/:player_uid", getPlayer)
 	}
 
 	authGroup := apiGroup.Group("")

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -25,15 +25,18 @@ type Pal struct {
 }
 
 type OnlinePlayer struct {
-	PlayerUid  string    `json:"player_uid"`
-	SteamId    string    `json:"steam_id"`
-	Nickname   string    `json:"nickname"`
-	Ip         string    `json:"ip"`
-	Ping       float64   `json:"ping"`
-	LocationX  float64   `json:"location_x"`
-	LocationY  float64   `json:"location_y"`
-	Level      int32     `json:"level"`
-	LastOnline time.Time `json:"last_online"`
+	PlayerUid     string    `json:"player_uid"`
+	UserId        string    `json:"user_id"`
+	SteamId       string    `json:"steam_id"`
+	Nickname      string    `json:"nickname"`
+	AccountName   string    `json:"account_name"`
+	Ip            string    `json:"ip"`
+	Ping          float64   `json:"ping"`
+	LocationX     float64   `json:"location_x"`
+	LocationY     float64   `json:"location_y"`
+	Level         int32     `json:"level"`
+	BuildingCount int32     `json:"building_count"`
+	LastOnline    time.Time `json:"last_online"`
 }
 
 type GuildPlayer struct {

--- a/internal/tool/rest_api.go
+++ b/internal/tool/rest_api.go
@@ -105,14 +105,16 @@ func Metrics() (map[string]interface{}, error) {
 }
 
 type ResponsePlayer struct {
-	Name      string  `json:"name"`
-	PlayerId  string  `json:"playerId"`
-	UserId    string  `json:"userId"`
-	Ip        string  `json:"ip"`
-	Ping      float64 `json:"ping"`
-	LocationX float64 `json:"location_x"`
-	LocationY float64 `json:"location_y"`
-	Level     int     `json:"level"`
+	Name          string  `json:"name"`
+	AccountName   string  `json:"accountName"`
+	PlayerId      string  `json:"playerId"`
+	UserId        string  `json:"userId"`
+	Ip            string  `json:"ip"`
+	Ping          float64 `json:"ping"`
+	LocationX     float64 `json:"location_x"`
+	LocationY     float64 `json:"location_y"`
+	Level         int     `json:"level"`
+	BuildingCount int     `json:"building_count"`
 }
 
 type ResponsePlayers struct {
@@ -132,15 +134,18 @@ func ShowPlayers() ([]database.OnlinePlayer, error) {
 	onlinePlayers := make([]database.OnlinePlayer, 0)
 	for _, player := range data.Players {
 		onlinePlayer := database.OnlinePlayer{
-			PlayerUid:  getPlayerUid(player.PlayerId),
-			SteamId:    getSteamId(player.UserId),
-			Nickname:   player.Name,
-			Ip:         player.Ip,
-			Ping:       player.Ping,
-			LocationX:  player.LocationX,
-			LocationY:  player.LocationY,
-			Level:      int32(player.Level),
-			LastOnline: time.Now(),
+			PlayerUid:     getPlayerUid(player.PlayerId),
+			UserId:        player.UserId,
+			AccountName:   player.AccountName,
+			SteamId:       getSteamId(player.UserId),
+			Nickname:      player.Name,
+			Ip:            player.Ip,
+			Ping:          player.Ping,
+			LocationX:     player.LocationX,
+			LocationY:     player.LocationY,
+			Level:         int32(player.Level),
+			BuildingCount: int32(player.BuildingCount),
+			LastOnline:    time.Now(),
 		}
 		onlinePlayers = append(onlinePlayers, onlinePlayer)
 	}

--- a/service/player.go
+++ b/service/player.go
@@ -85,8 +85,10 @@ func PutPlayersOnline(db *bbolt.DB, players []database.OnlinePlayer) error {
 			if existingPlayerData == nil {
 				// player online but not in database
 				player.PlayerUid = p.PlayerUid
+				player.UserId = p.UserId
 				player.SteamId = p.SteamId
 				player.Nickname = p.Nickname
+				player.AccountName = p.AccountName
 			} else {
 				if err := json.Unmarshal(existingPlayerData, &player); err != nil {
 					return err
@@ -94,12 +96,21 @@ func PutPlayersOnline(db *bbolt.DB, players []database.OnlinePlayer) error {
 				if player.SteamId == "" || strings.Contains(player.SteamId, "000000") {
 					player.SteamId = p.SteamId
 				}
+				// UserId 补充
+				if player.UserId == "" {
+					player.UserId = p.UserId
+				}
+				// AccountName 补充
+				if player.AccountName == "" {
+					player.AccountName = p.AccountName
+				}
 			}
 			player.Ip = p.Ip
 			player.Ping = p.Ping
 			player.LocationX = p.LocationX
 			player.LocationY = p.LocationY
 			player.Level = p.Level
+			player.BuildingCount = p.BuildingCount
 			player.LastOnline = time.Now()
 
 			v, err := json.Marshal(player)

--- a/web/src/views/PcHome/PcHome.vue
+++ b/web/src/views/PcHome/PcHome.vue
@@ -162,7 +162,7 @@ const getPlayerList = async () => {
   rconPlayerOptions.value = data.value.map((item) => {
     return {
       label: `${item.nickname}(${item.player_uid})`,
-      value: `${item.player_uid}-${item.steam_id}`,
+      value: `${item.player_uid}-${item.user_id}-${item.steam_id}`,
     };
   });
 };
@@ -316,34 +316,39 @@ const removeRconCommand = async (uuid) => {
 };
 const fillRconCommand = (rconCommand) => {
   let cmd = rconCommand.placeholder;
-  // {steamUserId}
-  if (cmd.includes("{steamUserId}")) {
+  // {steamUserID}，大小写不敏感
+  if (/{steamUserID}/i.test(cmd)) {
     if (!rconSelectedPlayer.value) {
       message.warning(t("message.selectPlayerFirst"));
       return;
     }
-    cmd = cmd.replaceAll(
-        "{steamUserId}",
-        "steam_"+rconSelectedPlayer.value.split("-")[1]
-    );
+    cmd = cmd.replace(/{steamUserID}/gi, "steam_" + rconSelectedPlayer.value.split("-")[2]);
   }
-  // {itemId}
-  if (cmd.includes("{itemId}")) {
+  // {userID}，大小写不敏感
+  if (/{userID}/i.test(cmd)) {
+    if (!rconSelectedPlayer.value) {
+      message.warning(t("message.selectPlayerFirst"));
+      return;
+    }
+    cmd = cmd.replace(/{userID}/gi, rconSelectedPlayer.value.split("-")[1]);
+  }
+  // {itemID}，大小写不敏感
+  if (/{itemID}/i.test(cmd)) {
     if (!rconSelectedItem.value) {
       message.warning(t("message.selectItemFirst"));
       return;
     }
-    cmd = cmd.replaceAll("{itemId}", rconSelectedItem.value);
+    cmd = cmd.replace(/{itemID}/gi, rconSelectedItem.value);
   }
-  // {palId}
-  if (cmd.includes("{palId}")) {
+  // {palID}，大小写不敏感
+  if (/{palID}/i.test(cmd)) {
     if (!rconSelectedPal.value) {
       message.warning(t("message.selectPalFirst"));
       return;
     }
-    cmd = cmd.replaceAll("{palId}", rconSelectedPal.value);
+    cmd = cmd.replace(/{palID}/gi, rconSelectedPal.value);
   }
-  // ⭐ 最终写回原来的输入框
+  // 最终写回原来的输入框
   rconCommandsExtra.value[rconCommand.uuid] = cmd;
 };
 
@@ -1292,10 +1297,10 @@ onMounted(async () => {
         </n-button> -->
       </div>
       <div class="flex w-full items-center mt-3 justify-between">
-        <n-text
-          >PlayerID: {{ rconSelectedPlayer?.split("-")[0] || "-" }}</n-text
-        >
-        <n-text>Steam64: {{ rconSelectedPlayer?.split("-")[1] || "-" }}</n-text>
+        <n-text>
+          PlayerID: {{ rconSelectedPlayer?.split("-")[0] || "-" }}
+        </n-text>
+        <n-text>UserID: {{ rconSelectedPlayer?.split("-")[1] || "-" }}</n-text>
       </div>
 
       <div class="flex w-full items-center mt-3">
@@ -1316,7 +1321,7 @@ onMounted(async () => {
         </n-button> -->
       </div>
       <div class="flex w-full items-center mt-3 justify-between">
-        <n-text>ID: {{ rconSelectedItem || "-" }}</n-text>
+        <n-text>ItemID: {{ rconSelectedItem || "-" }}</n-text>
       </div>
 
       <div class="flex w-full items-center mt-3">
@@ -1337,7 +1342,7 @@ onMounted(async () => {
         </n-button> -->
       </div>
       <div class="flex w-full items-center mt-3 justify-between">
-        <n-text>ID: {{ rconSelectedPal || "-" }}</n-text>
+        <n-text>PalID: {{ rconSelectedPal || "-" }}</n-text>
       </div>
       <n-empty class="mt-3" v-if="rconCommands.length == 0"> </n-empty>
       <n-collapse class="mt-3">

--- a/web/src/views/PcHome/component/PlayerList.vue
+++ b/web/src/views/PcHome/component/PlayerList.vue
@@ -28,6 +28,14 @@ const playerList = ref([]);
 const playerInfo = ref(null);
 const playerPalsList = ref([]);
 const skillTypeList = ref([]);
+// 平台标记颜色
+const platformColors = {
+  steam: { color: '#223D58', textColor: '#fff' },   // 青底白字
+  xbox:  { color: '#2B8B2B', textColor: '#fff' },   // 绿底白字
+  ps5:   { color: '#00439C', textColor: '#fff' },   // 蓝底白字
+  mac:   { color: '#999999', textColor: '#fff' },   // 灰底白字
+  default: { color: '#d9c36c', textColor: '#fff' }  // 其他平台
+}
 
 // 获取玩家列表
 const getPlayerList = async () => {
@@ -118,6 +126,11 @@ const getSkillTypeList = () => {
 const isPlayerOnline = (last_online) => {
   return dayjs() - dayjs(last_online) < 80000;
 };
+const getPlatformColor = (userId) => {
+  if (!userId) return platformColors.default;
+  const platform = userId.split('_')[0];
+  return platformColors[platform] || platformColors.default;
+}
 const displayLastOnline = (last_online) => {
   if (dayjs(last_online).year() < 1970) {
     return "Unknown";
@@ -177,9 +190,20 @@ const displayLastOnline = (last_online) => {
                 >
                   {{ $t("status.whitelist") }}
                 </n-tag>
-                <span class="flex-1 pl-2 font-bold line-clamp-1">{{
-                  player.nickname
-                }}</span>
+                <span class="flex-1 pl-2 font-bold line-clamp-1">
+                  {{ player.nickname }}
+                  <n-tag
+                      v-if="player.user_id"
+                      class=""
+                      style="line-height: 22px;"
+                      :bordered="false"
+                      round
+                      size="small"
+                      :color="getPlatformColor(player.user_id)"
+                  >
+                  {{ player.user_id.split("_")[0] }}
+                </n-tag>
+                </span>
               </div>
               <n-tag :bordered="false" round size="small" class="mt-2">
                 {{ $t("status.last_online") }}:


### PR DESCRIPTION
1. 同步 /v1/api/players 接口字段

对齐 /v1/api/players 接口，增加 accountName、building_count 字段，使数据结构与接口返回保持一致。

2.  对服务器支持跨平台后的userId做一些改进 #253 

现在完整保存带平台前缀的 userId，用于区分和识别玩家的登录平台（如 Steam、Xbox、PS5、mac）。（issue和论坛有提到但是限于条件无法测试，前缀判断可能需要等待反馈）
前端已增加对应的平台展示逻辑，目前仅对 Steam 平台进行了实际测试。
<img width="452" height="129" alt="image" src="https://github.com/user-attachments/assets/2e770ae8-0c03-45ce-bad9-cf4fade9a630" />
对相关的rcon功能也做了优化，占位符可以直接从界面上看到。
<img width="708" height="437" alt="image" src="https://github.com/user-attachments/assets/abe06eb6-da37-40c0-8a2d-570ad7cca650" />

3.  未登录状态下不再返回敏感信息 #239 #254 

调整未登录用户的返回数据，在未登录状态下不再返回 ip、userid、steamid