### PR TITLE
fix(docker): stabilize Go dependency downloads

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,6 +1,7 @@
 name: PST Docker Image CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -65,9 +66,10 @@ jobs:
         with:
           images: ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
-            type=semver,pattern={{version}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=edge,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+            type=sha,prefix=manual-,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push image
         uses: docker/build-push-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,11 +57,17 @@ RUN python -m pip install --no-cache-dir -r /tmp/sav-cli-requirements.lock \
 # --------- backend -----------
 FROM ${GO_IMAGE} AS backend-builder
 
-ARG proxy
 ARG version
 
 WORKDIR /app
-ADD . .
+
+# Keep Go module downloads independent from source and map changes so the
+# BuildKit/GitHub Actions cache can reuse this layer across releases. Use Go's
+# default GOPROXY instead of routing release builds through a custom proxy.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
 
 # Map tiles are versioned as Git LFS objects. Fail early when a checkout left
 # pointer files in place or when the tile pyramid is incomplete.
@@ -73,8 +79,7 @@ COPY --from=web-builder /app/index.html /app/index.html
 COPY --from=pal-conf-builder /app/pal-conf-assets/ /app/assets/
 COPY --from=pal-conf-builder /app/pal-conf.html /app/pal-conf.html
 
-RUN if [ -n "$proxy" ]; then export GOPROXY=https://goproxy.io,direct; fi \
-    && go build -ldflags="-s -w -X 'main.version=${version}'" -o /app/dist/pst main.go
+RUN go build -ldflags="-s -w -X 'main.version=${version}'" -o /app/dist/pst main.go
 
 
 # --------- runtime -----------


### PR DESCRIPTION
## 变更

- 删除 Dockerfile 中的 `proxy` 构建参数和 `goproxy.io,direct` 分支，使用 Go 默认模块代理。
- 将 `go mod download` 拆成独立缓存层，避免源码或 LFS 地图变化导致依赖重复下载。
- 为 PST Docker workflow 增加手动触发入口。
- 手动构建仅发布 `manual-<short-sha>` 标签，不覆盖 `edge`、正式版本或 `latest`。

## 原因

GitHub Actions 多次稳定卡在 Go 模块下载。本地复现显示自定义代理失败后回退到 `direct`，而 Alpine Go 构建阶段缺少 git；切换到 Go 默认代理后 amd64 和 arm64 后端均能完成编译。

## 验证

- `git diff --check`
- Docker BuildKit `--check`：无警告
- 自定义 proxy 静态回归检查通过
- workflow YAML 解析通过
- 手动 PST Docker 构建已启动：Actions run #29201265421